### PR TITLE
override _get_val_from_obj() to properly dump url.

### DIFF
--- a/django_qiniu/fields.py
+++ b/django_qiniu/fields.py
@@ -119,7 +119,10 @@ class QiNiuFileField(models.TextField):
 
     def get_db_prep_value(self, value, connection, prepared=False):
         if not prepared:
-            value = self.get_prep_value(value.url)
+            if hasattr(value, 'url'):
+                value = self.get_prep_value(value.url)
+            else:
+                value = self.get_prep_value(value)
         return value
 
     def get_uptoken(self):

--- a/django_qiniu/fields.py
+++ b/django_qiniu/fields.py
@@ -117,6 +117,11 @@ class QiNiuFileField(models.TextField):
         else:
             return self.get_default()
 
+    def get_db_prep_value(self, value, connection, prepared=False):
+        if not prepared:
+            value = self.get_prep_value(value.url)
+        return value
+
     def get_uptoken(self):
         policy = qiniu.rs.PutPolicy(self.upload_bucket)
         return policy.token()

--- a/django_qiniu/fields.py
+++ b/django_qiniu/fields.py
@@ -111,6 +111,12 @@ class QiNiuFileField(models.TextField):
         super(QiNiuFileField, self).contribute_to_class(cls, name)
         setattr(cls, self.name, self.descriptor_class(self))
 
+    def _get_val_from_obj(self, obj):
+        if obj is not None:
+            return getattr(obj, self.attname).url
+        else:
+            return self.get_default()
+
     def get_uptoken(self):
         policy = qiniu.rs.PutPolicy(self.upload_bucket)
         return policy.token()


### PR DESCRIPTION
when run `manage.py dumpdata`, it will properly dump url out, rather than useless memory object ref.
# before

```
"http://xxx.qiniudn.com/< sports.lib.django_qiniu.fields.QiNiuImageAttrClass object at 0x108f1b390 >"
```
# after

```
"http://xxx.qiniudn.com/hy.jpg"
```
